### PR TITLE
Changing .to_string to .to_hex_string to fix conflict and added a Display impl for Record

### DIFF
--- a/src/checksum.rs
+++ b/src/checksum.rs
@@ -15,8 +15,7 @@ pub fn checksum(data: &[u8]) -> u8 {
     let sum: u8 = data.iter()
         .fold(0, |acc, &value| acc.wrapping_add(value as u8));
 
-    let checksum = (0 as u8).wrapping_sub(sum);
-    checksum
+    (0 as u8).wrapping_sub(sum)
 }
 
 #[cfg(test)]

--- a/src/checksum.rs
+++ b/src/checksum.rs
@@ -12,10 +12,10 @@
  and taking the two's complement of the least significant byte of the sum.
  */
 pub fn checksum(data: &[u8]) -> u8 {
-    let sum: u8 = data.iter()
-        .fold(0, |acc, &value| acc.wrapping_add(value as u8));
-
-    (0 as u8).wrapping_sub(sum)
+    (0 as u8).wrapping_sub(
+        data.iter()
+        .fold(0, |acc, &value| acc.wrapping_add(value as u8)
+    ))
 }
 
 #[cfg(test)]

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -201,7 +201,7 @@ impl Record {
                         let cs = cs_hi | cs_lo;
                         let ip = ip_hi | ip_lo;
 
-                        Ok(Record::StartSegmentAddress { cs: cs, ip: ip })
+                        Ok(Record::StartSegmentAddress { cs, ip })
                     }
 
                     _ => Err(ReaderError::InvalidLengthForType),
@@ -278,8 +278,8 @@ impl<'a> Reader<'a> {
         Reader {
             line_iterator: string.lines(),
             finished: false,
-            stop_after_first_error: stop_after_first_error,
-            stop_after_eof: stop_after_eof,
+            stop_after_first_error,
+            stop_after_eof,
         }
     }
 
@@ -306,7 +306,7 @@ impl<'a> Reader<'a> {
             }
         }
 
-        return result;
+        result
     }
 }
 

--- a/src/record.rs
+++ b/src/record.rs
@@ -67,12 +67,12 @@ impl Record {
 impl fmt::Display for Record {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self {
-            &Record::Data { offset, value } => write!(f, "Data {{ offset: {}, values : {:?} }}", offset, value),
+            &Record::Data { offset, value } => write!(f, "Data {{ offset: {:#X}, value: {:?} }}", offset, value),
             &Record::EndOfFile => write!(f, "EndOfFile"),
-            &Record::ExtendedSegmentAddress(address) => write!(f, "{}", address),
-            &Record::StartSegmentAddress { cs, ip } => write!(f, "{}, {}", cs, ip),
-            &Record::ExtendedLinearAddress(address) => write!(f, "{}", address),
-            &Record::StartLinearAddress(address) => write!(f, "{}", address),
+            &Record::ExtendedSegmentAddress(address) => write!(f, "ExtendedSegmentAddress: {:#X}", address),
+            &Record::StartSegmentAddress { cs, ip } => write!(f, "StartSegmentAddress {{ CS: {:#X}, IP: {:#X} }}", cs, ip),
+            &Record::ExtendedLinearAddress(address) => write!(f, "ExtendedLinearAddress: {:#X}", address),
+            &Record::StartLinearAddress(address) => write!(f, "StartLinearAddress: {:#X}", address),
         }
     }
 }
@@ -128,16 +128,16 @@ mod tests {
             value: vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
         };
         let eof_record = Record::EndOfFile;
-        let extended_segment_address_record = Record::ExtendedSegmentAddress(0);
-        let start_segment_address_record = Record::StartSegmentAddress { cs: 0, ip: 0 };
-        let extended_linear_address_record = Record::ExtendedLinearAddress(0);
-        let start_linear_address_record = Record::StartLinearAddress(0);
+        let extended_segment_address_record = Record::ExtendedSegmentAddress(0x900);
+        let start_segment_address_record = Record::StartSegmentAddress { cs: 0x30, ip: 0x108 };
+        let extended_linear_address_record = Record::ExtendedLinearAddress(0x738);
+        let start_linear_address_record = Record::StartLinearAddress(0x893);
 
-        assert_eq!(format!("{}", data_record), "Data { offset: 0x14, value: [0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xA, 0xB, 0xC, 0xD, 0xE, 0xF, 0x10] }");
-        assert_eq!(format!("{}", eof_record), "");
-        assert_eq!(format!("{}", extended_segment_address_record), "");
-        assert_eq!(format!("{}", start_segment_address_record), "");
-        assert_eq!(format!("{}", extended_linear_address_record), "");
-        assert_eq!(format!("{}", start_linear_address_record), "");
+        assert_eq!(format!("{}", data_record), "Data { offset: 0x14, value: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16] }");
+        assert_eq!(format!("{}", eof_record), "EndOfFile");
+        assert_eq!(format!("{}", extended_segment_address_record), "ExtendedSegmentAddress: 0x900");
+        assert_eq!(format!("{}", start_segment_address_record), "StartSegmentAddress { CS: 0x30, IP: 0x108 }");
+        assert_eq!(format!("{}", extended_linear_address_record), "ExtendedLinearAddress: 0x738");
+        assert_eq!(format!("{}", start_linear_address_record), "StartLinearAddress: 0x893");
     }
 }

--- a/src/record.rs
+++ b/src/record.rs
@@ -7,7 +7,9 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-#[derive(PartialEq, Eq, Clone, Debug, Hash)]
+use std::fmt;
+
+#[derive(PartialEq, Eq, Debug, Clone, Hash)]
 pub enum Record {
     /// Specifies a 16-bit offset address and up to 255 bytes of data.
     /// Availability: I8HEX, I16HEX and I32HEX.
@@ -63,8 +65,8 @@ pub mod types {
 
 impl Record {
     /**
-   Returns the record type specifier corresponding to the receiver.
-   */
+    Returns the record type specifier corresponding to the receiver.
+    */
     pub fn record_type(&self) -> u8 {
         match self {
             &Record::Data { .. } => types::DATA,
@@ -73,6 +75,19 @@ impl Record {
             &Record::StartSegmentAddress { .. } => types::START_SEGMENT_ADDRESS,
             &Record::ExtendedLinearAddress(..) => types::EXTENDED_LINEAR_ADDRESS,
             &Record::StartLinearAddress(..) => types::START_LINEAR_ADDRESS,
+        }
+    }
+}
+
+impl fmt::Display for Record {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &*self {
+            Record::Data { offset, value } => write!(f, "{}, {:?}", offset, value),
+            Record::EndOfFile => write!(f, "EndOfFile"),
+            Record::ExtendedSegmentAddress(address) => write!(f, "{}", address),
+            Record::StartSegmentAddress { cs, ip } => write!(f, "{}, {}", cs, ip),
+            Record::ExtendedLinearAddress(address) => write!(f, "{}", address),
+            Record::StartLinearAddress(address) => write!(f, "{}", address),
         }
     }
 }
@@ -105,5 +120,4 @@ mod tests {
         let start_linear_address_record = Record::StartLinearAddress(0);
         assert_eq!(start_linear_address_record.record_type(), 0x05);
     }
-
 }

--- a/src/record.rs
+++ b/src/record.rs
@@ -81,13 +81,13 @@ impl Record {
 
 impl fmt::Display for Record {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match &*self {
-            Record::Data { offset, value } => write!(f, "{}, {:?}", offset, value),
-            Record::EndOfFile => write!(f, "EndOfFile"),
-            Record::ExtendedSegmentAddress(address) => write!(f, "{}", address),
-            Record::StartSegmentAddress { cs, ip } => write!(f, "{}, {}", cs, ip),
-            Record::ExtendedLinearAddress(address) => write!(f, "{}", address),
-            Record::StartLinearAddress(address) => write!(f, "{}", address),
+        match &self {
+            &Record::Data { offset, value } => write!(f, "{}, {:?}", offset, value),
+            &Record::EndOfFile => write!(f, "EndOfFile"),
+            &Record::ExtendedSegmentAddress(address) => write!(f, "{}", address),
+            &Record::StartSegmentAddress { cs, ip } => write!(f, "{}, {}", cs, ip),
+            &Record::ExtendedLinearAddress(address) => write!(f, "{}", address),
+            &Record::StartLinearAddress(address) => write!(f, "{}", address),
         }
     }
 }
@@ -119,5 +119,24 @@ mod tests {
 
         let start_linear_address_record = Record::StartLinearAddress(0);
         assert_eq!(start_linear_address_record.record_type(), 0x05);
+    }
+
+    fn test_display() {
+        let data_record = Record::Data {
+            offset: 20u16,
+            value: vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+        };
+        let eof_record = Record::EndOfFile;
+        let extended_segment_address_record = Record::ExtendedSegmentAddress(0);
+        let start_segment_address_record = Record::StartSegmentAddress { cs: 0, ip: 0 };
+        let extended_linear_address_record = Record::ExtendedLinearAddress(0);
+        let start_linear_address_record = Record::StartLinearAddress(0);
+
+        assert_eq!(format!("{}", data_record), "Data { offset: 0x14, value: [0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xA, 0xB, 0xC, 0xD, 0xE, 0xF, 0x10] }");
+        assert_eq!(format!("{}", eof_record), "");
+        assert_eq!(format!("{}", extended_segment_address_record), "");
+        assert_eq!(format!("{}", start_segment_address_record), "");
+        assert_eq!(format!("{}", extended_linear_address_record), "");
+        assert_eq!(format!("{}", start_linear_address_record), "");
     }
 }

--- a/src/record.rs
+++ b/src/record.rs
@@ -48,21 +48,6 @@ pub enum Record {
     StartLinearAddress(u32),
 }
 
-pub mod types {
-    /// Type specifier for a Data record.
-    pub const DATA: u8 = 0x00;
-    /// Type specifier for an End-Of-File record.
-    pub const END_OF_FILE: u8 = 0x01;
-    /// Type specifier for an Extended Segment Address record.
-    pub const EXTENDED_SEGMENT_ADDRESS: u8 = 0x02;
-    /// Type specifier for a Start Segment Address record.
-    pub const START_SEGMENT_ADDRESS: u8 = 0x03;
-    /// Type specifier for an Extended Linear Address record.
-    pub const EXTENDED_LINEAR_ADDRESS: u8 = 0x04;
-    /// Type specifier for a Start Linear Address record.
-    pub const START_LINEAR_ADDRESS: u8 = 0x05;
-}
-
 impl Record {
     /**
     Returns the record type specifier corresponding to the receiver.
@@ -82,7 +67,7 @@ impl Record {
 impl fmt::Display for Record {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self {
-            &Record::Data { offset, value } => write!(f, "{}, {:?}", offset, value),
+            &Record::Data { offset, value } => write!(f, "Data {{ offset: {}, values : {:?} }}", offset, value),
             &Record::EndOfFile => write!(f, "EndOfFile"),
             &Record::ExtendedSegmentAddress(address) => write!(f, "{}", address),
             &Record::StartSegmentAddress { cs, ip } => write!(f, "{}, {}", cs, ip),
@@ -90,6 +75,21 @@ impl fmt::Display for Record {
             &Record::StartLinearAddress(address) => write!(f, "{}", address),
         }
     }
+}
+
+pub mod types {
+    /// Type specifier for a Data record.
+    pub const DATA: u8 = 0x00;
+    /// Type specifier for an End-Of-File record.
+    pub const END_OF_FILE: u8 = 0x01;
+    /// Type specifier for an Extended Segment Address record.
+    pub const EXTENDED_SEGMENT_ADDRESS: u8 = 0x02;
+    /// Type specifier for a Start Segment Address record.
+    pub const START_SEGMENT_ADDRESS: u8 = 0x03;
+    /// Type specifier for an Extended Linear Address record.
+    pub const EXTENDED_LINEAR_ADDRESS: u8 = 0x04;
+    /// Type specifier for a Start Linear Address record.
+    pub const START_LINEAR_ADDRESS: u8 = 0x05;
 }
 
 #[cfg(test)]
@@ -121,6 +121,7 @@ mod tests {
         assert_eq!(start_linear_address_record.record_type(), 0x05);
     }
 
+    #[test]
     fn test_display() {
         let data_record = Record::Data {
             offset: 20u16,

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -186,9 +186,9 @@ pub fn create_object_file_representation(records: &[Record]) -> Result<String, W
         return Err(WriterError::MultipleEndOfFileRecords(eof_record_count));
     }
 
-    records
+    Ok(records
         .iter()
         .map(|ref record| record.to_string())
-        .collect::<Result<Vec<String>, WriterError>>()
-        .map(|list| list.join("\n"))
+        .collect::<Vec<String>>()
+        .join("\n"))
 }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -91,10 +91,10 @@ impl Record {
                 self.record_type(),
                 0x0000,
                 &[
-                    ((address & 0xFF000000) >> 24) as u8,
-                    ((address & 0x00FF0000) >> 16) as u8,
-                    ((address & 0x0000FF00) >> 8) as u8,
-                    ((address & 0x000000FF) >> 0) as u8,
+                    ((address & 0xFF00_0000) >> 24) as u8,
+                    ((address & 0x00FF_0000) >> 16) as u8,
+                    ((address & 0x0000_FF00) >> 8) as u8,
+                    ((address & 0x0000_00FF) >> 0) as u8,
                 ],
             ),
         }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -50,7 +50,7 @@ impl Record {
     ///
     /// Returns the IHEX record representation of the receiver, or an error on failure.
     ///
-    pub fn to_string(&self) -> Result<String, WriterError> {
+    pub fn to_hex_string(&self) -> Result<String, WriterError> {
         match self {
             &Record::Data { offset, ref value } => {
                 format_record(self.record_type(), offset, value.as_slice())
@@ -186,9 +186,9 @@ pub fn create_object_file_representation(records: &[Record]) -> Result<String, W
         return Err(WriterError::MultipleEndOfFileRecords(eof_record_count));
     }
 
-    Ok(records
+    records
         .iter()
-        .map(|ref record| record.to_string())
-        .collect::<Vec<String>>()
-        .join("\n"))
+        .map(|ref record| record.to_hex_string())
+        .collect::<Result<Vec<String>, WriterError>>()
+        .map(|list| list.join("\n"))
 }

--- a/tests/test_reader.rs
+++ b/tests/test_reader.rs
@@ -43,7 +43,7 @@ fn test_record_from_record_string_rejects_long_records() {
         offset: 0x0010,
         value: longest_valid_data,
     };
-    let longest_valid_string = longest_valid_data_record.to_string().unwrap();
+    let longest_valid_string = longest_valid_data_record.to_hex_string().unwrap();
     let shortest_invalid_string = longest_valid_string.clone() + &"0";
 
     assert_eq!(longest_valid_string.len(), 521);

--- a/tests/test_writer.rs
+++ b/tests/test_writer.rs
@@ -19,7 +19,7 @@ fn test_record_to_string_for_data_record() {
         value: vec![],
     };
     assert_eq!(
-        empty_data_record.to_string(),
+        empty_data_record.to_hex_string(),
         Ok(String::from(":0000000000"))
     );
 
@@ -31,7 +31,7 @@ fn test_record_to_string_for_data_record() {
         value: data,
     };
     assert_eq!(
-        populated_data_record.to_string(),
+        populated_data_record.to_hex_string(),
         Ok(String::from(":0B0010006164647265737320676170A7"))
     );
 
@@ -41,7 +41,7 @@ fn test_record_to_string_for_data_record() {
         offset: 0x0000,
         value: max_length_data,
     };
-    assert_eq!(max_length_data_record.to_string().is_ok(), true);
+    assert_eq!(max_length_data_record.to_hex_string().is_ok(), true);
 }
 
 #[test]
@@ -52,7 +52,7 @@ fn test_record_to_string_for_data_record_with_invalid_data() {
         value: invalid_data,
     };
     assert_eq!(
-        invalid_data_record.to_string(),
+        invalid_data_record.to_hex_string(),
         Err(WriterError::DataExceedsMaximumLength(256))
     );
 }
@@ -60,20 +60,20 @@ fn test_record_to_string_for_data_record_with_invalid_data() {
 #[test]
 fn test_record_to_string_for_eof_record() {
     let eof_record = Record::EndOfFile;
-    assert_eq!(eof_record.to_string(), Ok(String::from(":00000001FF")));
+    assert_eq!(eof_record.to_hex_string(), Ok(String::from(":00000001FF")));
 }
 
 #[test]
 fn test_record_to_string_for_esa_record() {
     let esa_record_1 = Record::ExtendedSegmentAddress(0x1200);
     assert_eq!(
-        esa_record_1.to_string(),
+        esa_record_1.to_hex_string(),
         Ok(String::from(":020000021200EA"))
     );
 
     let esa_record_2 = Record::ExtendedSegmentAddress(0x55AA);
     assert_eq!(
-        esa_record_2.to_string(),
+        esa_record_2.to_hex_string(),
         Ok(String::from(":0200000255AAFD"))
     );
 }
@@ -85,7 +85,7 @@ fn test_record_to_string_for_ssa_record() {
         ip: 0x3801,
     };
     assert_eq!(
-        ssa_record_1.to_string(),
+        ssa_record_1.to_hex_string(),
         Ok(String::from(":0400000301103801AF"))
     );
 
@@ -94,7 +94,7 @@ fn test_record_to_string_for_ssa_record() {
         ip: 0x3800,
     };
     assert_eq!(
-        ssa_record_2.to_string(),
+        ssa_record_2.to_hex_string(),
         Ok(String::from(":0400000300003800C1"))
     );
 }
@@ -103,13 +103,13 @@ fn test_record_to_string_for_ssa_record() {
 fn test_record_to_string_for_ela_record() {
     let ela_record_1 = Record::ExtendedLinearAddress(0xFFFF);
     assert_eq!(
-        ela_record_1.to_string(),
+        ela_record_1.to_hex_string(),
         Ok(String::from(":02000004FFFFFC"))
     );
 
     let ela_record_2 = Record::ExtendedLinearAddress(0x0F55);
     assert_eq!(
-        ela_record_2.to_string(),
+        ela_record_2.to_hex_string(),
         Ok(String::from(":020000040F5596"))
     );
 }
@@ -118,13 +118,13 @@ fn test_record_to_string_for_ela_record() {
 fn test_record_to_string_for_sla_record() {
     let sla_record_1 = Record::StartLinearAddress(0x000000CD);
     assert_eq!(
-        sla_record_1.to_string(),
+        sla_record_1.to_hex_string(),
         Ok(String::from(":04000005000000CD2A"))
     );
 
     let sla_record_2 = Record::StartLinearAddress(0x11223344);
     assert_eq!(
-        sla_record_2.to_string(),
+        sla_record_2.to_hex_string(),
         Ok(String::from(":04000005112233444D"))
     );
 }


### PR DESCRIPTION
I have done some clean up using clippy recommendations.

I changed .to_string to .to_hex_string to prevent it conflicting with the .to_string method which I think is part of the std library.

I added a Display impl for Record which outputs the addresses in HEX to help with address debugging.