### PR TITLE
IHEX 2.0: 2018 Edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-version = "1.1.2"
+version = "2.0.0"
 
 name = "ihex"
 authors = ["Martin Mroz <martinmroz@gmail.com>"]
@@ -10,5 +10,6 @@ documentation = "https://martinmroz.github.io/ihex/master/ihex/"
 readme = "README.md"
 keywords = ["ihex", "intel", "hex"]
 license = "MIT OR Apache-2.0"
+edition = "2018"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ Add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-ihex = "1.1"
+ihex = "2.0"
 ```
 
-In addition, and this to your crate root:
+In addition, for Rust 2015 edition projects, and this to your crate root:
 
 ```rust
 extern crate ihex;
@@ -30,10 +30,7 @@ Here is an example which builds an IHEX object file with test data and prints it
 
 
 ```rust
-extern crate ihex;
-
-use ihex::record::Record;
-use ihex::writer;
+use ihex::Record;
 
 fn main() {
     let records = &[
@@ -41,7 +38,7 @@ fn main() {
         Record::EndOfFile
     ];
 
-    if let Ok(object) = writer::create_object_file_representation(records) {
+    if let Ok(object) = ihex::create_object_file_representation(records) {
         println!("{}", object);
     }
 }

--- a/src/checksum.rs
+++ b/src/checksum.rs
@@ -7,20 +7,23 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-/**
- Computes the Intel HEX checksum of `data`. This is done by summing all the bytes `data
- and taking the two's complement of the least significant byte of the sum.
- */
-pub fn checksum(data: &[u8]) -> u8 {
+///
+/// Computes the Intel HEX checksum of `data`. This is done by summing all the bytes `data
+/// and taking the two's complement of the least significant byte of the sum.
+///
+pub fn checksum<T>(data: T) -> u8
+where
+    T: AsRef<[u8]>,
+{
     (0 as u8).wrapping_sub(
-        data.iter()
-        .fold(0, |acc, &value| acc.wrapping_add(value as u8)
-    ))
+        data.as_ref()
+            .iter()
+            .fold(0, |acc, &value| acc.wrapping_add(value as u8)),
+    )
 }
 
 #[cfg(test)]
 mod tests {
-
     use super::*;
 
     #[test]
@@ -45,5 +48,4 @@ mod tests {
             0x2A
         );
     }
-
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,14 +13,12 @@
 //! This format is commonly used for representing compiled program code and
 //! data to be loaded into a microcontroller, flash memory or ROM.
 
-/// Function for computing IHEX checksum.
-pub mod checksum;
+mod checksum;
+mod reader;
+mod record;
+mod writer;
 
-/// Operations for parsing IHEX records and object files.
-pub mod reader;
-
-/// An Intel HEX record type.
-pub mod record;
-
-/// Operations for generating IHEX records and object files.
-pub mod writer;
+pub use checksum::*;
+pub use reader::*;
+pub use record::*;
+pub use writer::*;

--- a/src/record.rs
+++ b/src/record.rs
@@ -7,8 +7,6 @@
 // copied, modified, or distributed except according to those terms.
 //
 
-use std::fmt;
-
 #[derive(PartialEq, Eq, Debug, Clone, Hash)]
 pub enum Record {
     /// Specifies a 16-bit offset address and up to 255 bytes of data.
@@ -49,30 +47,17 @@ pub enum Record {
 }
 
 impl Record {
-    /**
-    Returns the record type specifier corresponding to the receiver.
-    */
+    ///
+    /// The record type specifier corresponding to the receiver.
+    ///
     pub fn record_type(&self) -> u8 {
         match self {
-            &Record::Data { .. } => types::DATA,
-            &Record::EndOfFile => types::END_OF_FILE,
-            &Record::ExtendedSegmentAddress(..) => types::EXTENDED_SEGMENT_ADDRESS,
-            &Record::StartSegmentAddress { .. } => types::START_SEGMENT_ADDRESS,
-            &Record::ExtendedLinearAddress(..) => types::EXTENDED_LINEAR_ADDRESS,
-            &Record::StartLinearAddress(..) => types::START_LINEAR_ADDRESS,
-        }
-    }
-}
-
-impl fmt::Display for Record {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match &self {
-            &Record::Data { offset, value } => write!(f, "Data {{ offset: {:#X}, value: {:?} }}", offset, value),
-            &Record::EndOfFile => write!(f, "EndOfFile"),
-            &Record::ExtendedSegmentAddress(address) => write!(f, "ExtendedSegmentAddress: {:#X}", address),
-            &Record::StartSegmentAddress { cs, ip } => write!(f, "StartSegmentAddress {{ CS: {:#X}, IP: {:#X} }}", cs, ip),
-            &Record::ExtendedLinearAddress(address) => write!(f, "ExtendedLinearAddress: {:#X}", address),
-            &Record::StartLinearAddress(address) => write!(f, "StartLinearAddress: {:#X}", address),
+            Record::Data { .. } => types::DATA,
+            Record::EndOfFile => types::END_OF_FILE,
+            Record::ExtendedSegmentAddress(..) => types::EXTENDED_SEGMENT_ADDRESS,
+            Record::StartSegmentAddress { .. } => types::START_SEGMENT_ADDRESS,
+            Record::ExtendedLinearAddress(..) => types::EXTENDED_LINEAR_ADDRESS,
+            Record::StartLinearAddress(..) => types::START_LINEAR_ADDRESS,
         }
     }
 }
@@ -94,7 +79,6 @@ pub mod types {
 
 #[cfg(test)]
 mod tests {
-
     use super::*;
 
     #[test]
@@ -119,25 +103,5 @@ mod tests {
 
         let start_linear_address_record = Record::StartLinearAddress(0);
         assert_eq!(start_linear_address_record.record_type(), 0x05);
-    }
-
-    #[test]
-    fn test_display() {
-        let data_record = Record::Data {
-            offset: 20u16,
-            value: vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
-        };
-        let eof_record = Record::EndOfFile;
-        let extended_segment_address_record = Record::ExtendedSegmentAddress(0x900);
-        let start_segment_address_record = Record::StartSegmentAddress { cs: 0x30, ip: 0x108 };
-        let extended_linear_address_record = Record::ExtendedLinearAddress(0x738);
-        let start_linear_address_record = Record::StartLinearAddress(0x893);
-
-        assert_eq!(format!("{}", data_record), "Data { offset: 0x14, value: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16] }");
-        assert_eq!(format!("{}", eof_record), "EndOfFile");
-        assert_eq!(format!("{}", extended_segment_address_record), "ExtendedSegmentAddress: 0x900");
-        assert_eq!(format!("{}", start_segment_address_record), "StartSegmentAddress { CS: 0x30, IP: 0x108 }");
-        assert_eq!(format!("{}", extended_linear_address_record), "ExtendedLinearAddress: 0x738");
-        assert_eq!(format!("{}", start_linear_address_record), "StartLinearAddress: 0x893");
     }
 }

--- a/tests/test_reader.rs
+++ b/tests/test_reader.rs
@@ -7,10 +7,7 @@
 // distributed except according to those terms.
 //
 
-extern crate ihex;
-
-use ihex::reader::*;
-use ihex::record::Record;
+use ihex::*;
 
 #[test]
 fn test_record_from_record_string_rejects_missing_start_code() {
@@ -225,9 +222,7 @@ fn test_record_from_record_string_parses_valid_data_records() {
         Record::from_record_string(":0B0010006164647265737320676170A7"),
         Ok(Record::Data {
             offset: 0x0010,
-            value: vec![
-                0x61, 0x64, 0x64, 0x72, 0x65, 0x73, 0x73, 0x20, 0x67, 0x61, 0x70,
-            ],
+            value: vec![0x61, 0x64, 0x64, 0x72, 0x65, 0x73, 0x73, 0x20, 0x67, 0x61, 0x70,],
         })
     );
 
@@ -354,7 +349,13 @@ fn test_reader_respects_stop_after_first_error_false() {
         ip: 0x3800,
     };
 
-    let mut reader = Reader::new_stopping_after_error_and_eof(&input, false, false);
+    let mut reader = Reader::new_with_options(
+        &input,
+        ReaderOptions {
+            stop_after_first_error: false,
+            stop_after_eof: false,
+        },
+    );
     assert_eq!(reader.next(), Some(Ok(data_rec)));
     assert_eq!(reader.next(), Some(Err(ReaderError::RecordTooShort)));
     assert_eq!(reader.next(), Some(Ok(ssa_rec)));
@@ -373,7 +374,13 @@ fn test_reader_respects_stop_after_first_error_true() {
         ],
     };
 
-    let mut reader = Reader::new_stopping_after_error_and_eof(&input, true, false);
+    let mut reader = Reader::new_with_options(
+        &input,
+        ReaderOptions {
+            stop_after_first_error: true,
+            stop_after_eof: false,
+        },
+    );
     assert_eq!(reader.next(), Some(Ok(data_rec)));
     assert_eq!(reader.next(), Some(Err(ReaderError::RecordTooShort)));
     assert_eq!(reader.next(), None);
@@ -398,7 +405,13 @@ fn test_reader_respects_stop_after_first_eof_false() {
     };
     let eof_rec = Record::EndOfFile;
 
-    let mut reader = Reader::new_stopping_after_error_and_eof(&input, false, false);
+    let mut reader = Reader::new_with_options(
+        &input,
+        ReaderOptions {
+            stop_after_first_error: false,
+            stop_after_eof: false,
+        },
+    );
     assert_eq!(reader.next(), Some(Ok(data_rec)));
     assert_eq!(reader.next(), Some(Ok(eof_rec)));
     assert_eq!(reader.next(), Some(Ok(ssa_rec)));
@@ -420,7 +433,13 @@ fn test_reader_respects_stop_after_first_eof_true() {
     };
     let eof_rec = Record::EndOfFile;
 
-    let mut reader = Reader::new_stopping_after_error_and_eof(&input, false, true);
+    let mut reader = Reader::new_with_options(
+        &input,
+        ReaderOptions {
+            stop_after_first_error: false,
+            stop_after_eof: true,
+        },
+    );
     assert_eq!(reader.next(), Some(Ok(data_rec)));
     assert_eq!(reader.next(), Some(Ok(eof_rec)));
     assert_eq!(reader.next(), None);
@@ -506,7 +525,13 @@ fn test_reader_respects_ignores_extra_newlines() {
     };
     let eof_rec = Record::EndOfFile;
 
-    let mut reader = Reader::new_stopping_after_error_and_eof(&input, false, true);
+    let mut reader = Reader::new_with_options(
+        &input,
+        ReaderOptions {
+            stop_after_first_error: false,
+            stop_after_eof: true,
+        },
+    );
     assert_eq!(reader.next(), Some(Ok(data_rec)));
     assert_eq!(reader.next(), Some(Ok(eof_rec)));
     assert_eq!(reader.next(), None);

--- a/tests/test_writer.rs
+++ b/tests/test_writer.rs
@@ -7,10 +7,7 @@
 // distributed except according to those terms.
 //
 
-extern crate ihex;
-
-use ihex::record::Record;
-use ihex::writer::*;
+use ihex::*;
 
 #[test]
 fn test_record_to_string_for_data_record() {
@@ -167,7 +164,7 @@ fn test_create_object_file_representation_with_multiple_eof_records() {
 #[test]
 fn test_create_object_file_representation_eof_only() {
     let records = &[Record::EndOfFile];
-    let expected_result = String::from(":00000001FF");
+    let expected_result = String::from(":00000001FF\n");
     assert_eq!(
         create_object_file_representation(records),
         Ok(expected_result)
@@ -199,7 +196,7 @@ fn test_create_object_file_representation_all_types() {
         + &":0400000300003800C1\n"
         + &":02000004FFFFFC\n"
         + &":04000005000000CD2A\n"
-        + &":00000001FF";
+        + &":00000001FF\n";
 
     assert_eq!(
         create_object_file_representation(records),


### PR DESCRIPTION
- Moved to Rust 2018 edition.
- Applied all suggested lints from clippy.
- Applied all suggested formatting changes from cargo fmt.
- Removed conflicting implementation of Record::to_string (should-out to @skrapi)
- Moved Reader options into a new `ReaderOptions` type for clarity.
- Flattened the top-level module namespace.
- Various tweaks and performance enhancements.

NOTE: The change from `Record::to_string` into `to_hex_string`, `ReaderOptions` and module structure is a breaking source-level change, taking this from 1.1 to 2.0.