### PR TITLE
Ignoring characters preceding start code 

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -102,10 +102,7 @@ impl Record {
     /// ```
     ///
     pub fn from_record_string(string: &str) -> Result<Self, ReaderError> {
-        let clean_string = string
-            .replace(" ", "")
-            .trim_start_matches(|c| c != ':')
-            .to_string();
+        let clean_string = string.trim_start_matches(|c| c != ':').to_string();
         if let Some(':') = clean_string.chars().next() {
         } else {
             return Err(ReaderError::MissingStartCode);

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -102,13 +102,17 @@ impl Record {
     /// ```
     ///
     pub fn from_record_string(string: &str) -> Result<Self, ReaderError> {
-        if let Some(':') = string.chars().next() {
+        let clean_string = string
+            .replace(" ", "")
+            .trim_start_matches(|c| c != ':')
+            .to_string();
+        if let Some(':') = clean_string.chars().next() {
         } else {
             return Err(ReaderError::MissingStartCode);
         }
 
-        let data_portion = &string[1..];
-        let data_poriton_length = data_portion.chars().count();
+        let data_portion = &clean_string[1..];
+        let data_portion_length = data_portion.chars().count();
 
         // Validate all characters are hexadecimal before checking the digit counts for more accurate errors.
         if !data_portion

--- a/tests/test_reader.rs
+++ b/tests/test_reader.rs
@@ -10,6 +10,12 @@
 use ihex::*;
 
 #[test]
+fn test_record_from_record_string_ignore_preceding_start_code() -> Result<(), ihex::ReaderError> {
+    Record::from_record_string("wponadwoiand w03421 :00000001FF")?;
+    Ok(())
+}
+
+#[test]
 fn test_record_from_record_string_rejects_missing_start_code() {
     assert_eq!(
         Record::from_record_string("00000001FF"),


### PR DESCRIPTION
Ignore any characters preceding the start code, and remove any space in the line.

I don't know why have two others commit should have done something bad, it was the first time I did a PR. My bad.