### PR TITLE
Performance improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,9 @@ keywords = ["ihex", "intel", "hex"]
 license = "MIT OR Apache-2.0"
 edition = "2018"
 
-[dependencies]
+[dev-dependencies]
+criterion = "0.3"
+
+[[bench]]
+name = "benchmark_reader"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,7 @@ criterion = "0.3"
 [[bench]]
 name = "benchmark_reader"
 harness = false
+
+[[bench]]
+name = "benchmark_writer"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ keywords = ["ihex", "intel", "hex"]
 license = "MIT OR Apache-2.0"
 edition = "2018"
 
+[dependencies]
+hex-simd = "0.8"
+
 [dev-dependencies]
 criterion = "0.3"
 

--- a/benches/benchmark_reader.rs
+++ b/benches/benchmark_reader.rs
@@ -1,0 +1,13 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use ihex::Record;
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("Record::from_record_string", |b| {
+        b.iter(|| {
+            Record::from_record_string(black_box(":0B0010006164647265737320676170A7")).unwrap()
+        })
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/benches/benchmark_writer.rs
+++ b/benches/benchmark_writer.rs
@@ -1,0 +1,30 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use ihex::{create_object_file_representation, Record};
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    let records = &[
+        Record::Data {
+            offset: 0x0010,
+            value: vec![
+                0x61, 0x64, 0x64, 0x72, 0x65, 0x73, 0x73, 0x20, 0x67, 0x61, 0x70,
+            ],
+        },
+        Record::ExtendedSegmentAddress(0x1200),
+        Record::StartSegmentAddress {
+            cs: 0x0000,
+            ip: 0x3800,
+        },
+        Record::ExtendedLinearAddress(0xFFFF),
+        Record::StartLinearAddress(0x000000CD),
+        Record::EndOfFile,
+    ];
+
+    c.bench_function("create_object_file_representation", |b| {
+        b.iter(|| {
+            create_object_file_representation(black_box(records)).unwrap();
+        })
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/src/checksum.rs
+++ b/src/checksum.rs
@@ -15,10 +15,10 @@ pub fn checksum<T>(data: T) -> u8
 where
     T: AsRef<[u8]>,
 {
-    (0 as u8).wrapping_sub(
+    0u8.wrapping_sub(
         data.as_ref()
             .iter()
-            .fold(0, |acc, &value| acc.wrapping_add(value as u8)),
+            .fold(0, |acc, &value| acc.wrapping_add(value)),
     )
 }
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -297,7 +297,7 @@ impl<'a> Reader<'a> {
         let mut result = None;
 
         // Locate the first non-empty line.
-        while let Some(line) = self.line_iterator.next() {
+        for line in self.line_iterator.by_ref() {
             if !line.is_empty() {
                 result = Some(line);
                 break;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -108,7 +108,7 @@ impl Record {
         }
 
         let data_portion = &string[1..];
-        let data_portion_length = data_portion.chars().count();
+        let data_portion_length = data_portion.len();
 
         // Basic sanity-checking the input record string.
         if data_portion_length < char_counts::SMALLEST_RECORD_EXCLUDING_START_CODE {

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -125,8 +125,7 @@ impl Record {
 
         // Compute the checksum.
         let expected_checksum = data_bytes.pop().unwrap();
-        let validated_region_bytes = data_bytes.as_slice();
-        let checksum = checksum(validated_region_bytes);
+        let checksum = checksum(&data_bytes);
 
         // The read is failed if the checksum does not match.
         if checksum != expected_checksum {
@@ -134,12 +133,12 @@ impl Record {
         }
 
         // Decode header values.
-        let length = validated_region_bytes[0];
-        let address_hi = (validated_region_bytes[1] as u16) << 8;
-        let address_lo = validated_region_bytes[2] as u16;
+        let length = data_bytes[0];
+        let address_hi = (data_bytes[1] as u16) << 8;
+        let address_lo = data_bytes[2] as u16;
         let address = address_hi | address_lo;
-        let record_type = validated_region_bytes[3];
-        let payload_bytes = &validated_region_bytes[4..];
+        let record_type = data_bytes[3];
+        let payload_bytes = data_bytes.split_off(4);
 
         // Validate the length of the record matches what was specified in the header.
         if payload_bytes.len() != (length as usize) {
@@ -151,7 +150,7 @@ impl Record {
                 // A Data record consists of an address and payload bytes.
                 Ok(Record::Data {
                     offset: address,
-                    value: Vec::from(payload_bytes),
+                    value: payload_bytes,
                 })
             }
 

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -54,12 +54,12 @@ impl Record {
         match self {
             Record::Data { offset, value } => format_record(self.record_type(), *offset, value),
 
-            Record::EndOfFile => format_record(self.record_type(), 0x0000, &[]),
+            Record::EndOfFile => format_record(self.record_type(), 0x0000, []),
 
             Record::ExtendedSegmentAddress(segment_address) => format_record(
                 self.record_type(),
                 0x0000,
-                &[
+                [
                     ((segment_address & 0xFF00) >> 8) as u8,
                     (segment_address & 0x00FF) as u8,
                 ],
@@ -68,7 +68,7 @@ impl Record {
             Record::StartSegmentAddress { cs, ip } => format_record(
                 self.record_type(),
                 0x0000,
-                &[
+                [
                     ((cs & 0xFF00) >> 8) as u8,
                     (cs & 0x00FF) as u8,
                     ((ip & 0xFF00) >> 8) as u8,
@@ -79,7 +79,7 @@ impl Record {
             Record::ExtendedLinearAddress(linear_address) => format_record(
                 self.record_type(),
                 0x0000,
-                &[
+                [
                     ((linear_address & 0xFF00) >> 8) as u8,
                     (linear_address & 0x00FF) as u8,
                 ],
@@ -88,7 +88,7 @@ impl Record {
             Record::StartLinearAddress(address) => format_record(
                 self.record_type(),
                 0x0000,
-                &[
+                [
                     ((address & 0xFF00_0000) >> 24) as u8,
                     ((address & 0x00FF_0000) >> 16) as u8,
                     ((address & 0x0000_FF00) >> 8) as u8,
@@ -187,7 +187,7 @@ pub fn create_object_file_representation(records: &[Record]) -> Result<String, W
 
     records.iter().try_fold(String::new(), |mut acc, record| {
         acc.push_str(&record.to_record_string()?);
-        acc.push_str("\n");
+        acc.push('\n');
         Ok(acc)
     })
 }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -9,7 +9,6 @@
 
 use std::error::Error;
 use std::fmt;
-use std::fmt::Write;
 
 use crate::checksum::checksum;
 use crate::record::Record;
@@ -131,7 +130,7 @@ where
     data_region.extend_from_slice(data);
 
     // Compute the checksum of the data region thus far and append it.
-    let checksum = checksum(data_region.as_slice());
+    let checksum = checksum(&data_region);
     data_region.push(checksum);
 
     // The result string is twice as long as the record plus the start code.
@@ -140,11 +139,10 @@ where
 
     // Construct the record.
     result.push(':');
-    data_region.iter().try_fold(result, |mut acc, byte| {
-        write!(&mut acc, "{:02X}", byte)
-            .map_err(|_| WriterError::SynthesisFailed)
-            .map(|_| acc)
-    })
+
+    hex_simd::encode_append(data_region, &mut result, hex_simd::AsciiCase::Upper);
+
+    Ok(result)
 }
 
 ///


### PR DESCRIPTION
Thank you for this library!

This PR includes a few performance improvements that make reading/writing HEX files with ihex significantly faster. Not just in the micro benchmarks that I added, but also in a real world application. In particular: `Record::from_record_string` is now ~5x faster. And `create_object_file_representation` is now ~4x faster.

The main reason for this is the usage of the `hex-simd` crate for (de)serializing HEX-encoded strings. I tried two other crates (`data-encoding` and `faster-hex`), but both were slower. The downside is of course, that this library is not "dependency free" anymore.

I also added some minor readability improvements, but those are separate commits, so I can also easily remove them.